### PR TITLE
Switch ruma-client to master branch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,3 @@ version = "0.1.3"
 
 [dependencies.ruma-client]
 git = "https://github.com/jplatte/ruma-client.git"
-branch = "synapse-workarounds"


### PR DESCRIPTION
The "synapse-workarounds" branch doesn't exist anymore, so Cargo would
fail to download it.